### PR TITLE
Fix: Map docker port to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
       context: .
     ports:
-      - 8000
+      - 8000:8000
     environment:
       DEBUG: 1
       SECRET_KEY: '2rwns^_yyzwtv*x7h(cw#+jx#k0-9v)o+&l2p@l1c*f9mb*#&q'


### PR DESCRIPTION
When doing docker compose as the ports aren't mapped to localhost:8000, the server isn't reacheable, after this mapping I was able to view the site on localhost:8000. pls review.